### PR TITLE
Fix lua library not found under mingw.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ undefined:
 
 mingw : TARGET := ej2d.exe
 mingw : CFLAGS += -I/usr/include -I/usr/local/include
-mingw : LDFLAGS += -L/usr/bin -lgdi32 -lglew32 -lopengl32 -L/usr/local/bin -llua52
+mingw : LDFLAGS += -L/usr/bin -lgdi32 -lglew32 -lopengl32 -L/usr/local/lib -llua
 mingw : SRC += mingw/window.c mingw/winfw.c mingw/winfont.c
 
 mingw : $(SRC) ej2d


### PR DESCRIPTION
用的是最新的 mingw，lua  5.2.3  `make install` 后生成`C:\MinGW\msys\1.0\local\lib\liblua.a` 。
