### PR TITLE
Fixed the X11 exiting error.

### DIFF
--- a/posix/window.c
+++ b/posix/window.c
@@ -165,6 +165,7 @@ main(int argc, char *argv[]) {
                 if (keychar[0] == 'q' || keychar[0] == 'Q') {
                     close_x();
                 }
+                break;
             case ButtonPress: 
                 ejoy2d_win_touch(event.xbutton.x, event.xbutton.y, TOUCH_BEGIN); 
                 break;


### PR DESCRIPTION
Now can gracefully close a X11 window. Also can press q or Q to quit, this is not necessary though.
