### PR TITLE
fix #if __IPHONE_OS_VERSION_MAX_ALLOWED crossplatform bug

### DIFF
--- a/lua/loslib.c
+++ b/lua/loslib.c
@@ -15,8 +15,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0
-#include <spawn.h>
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED)
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0
+        #include <spawn.h>
+    #endif
 #endif
 
 #include "lua.h"
@@ -114,11 +116,18 @@
 
 static int os_execute (lua_State *L) {
   const char *cmd = luaL_optstring(L, 1, NULL);
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0
-    pid_t child_pid;
-    int stat = posix_spawn(&child_pid,cmd,NULL,NULL,NULL,NULL);
-#else
-    int stat = system(cmd);
+    int stat;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED)
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0
+        pid_t child_pid;
+        stat = posix_spawn(&child_pid,cmd,NULL,NULL,NULL,NULL);
+    #else
+        stat = system(cmd);
+    #endif
+#endif
+
+#if !defined(__IPHONE_OS_VERSION_MAX_ALLOWED)
+    stat = system(cmd);
 #endif
   if (cmd != NULL)
     return luaL_execresult(L, stat);


### PR DESCRIPTION
判断了 __IPHONE_OS_VERSION_MAX_ALLOWED 宏在不同平台未定义问题。